### PR TITLE
Small updates (aiidalab, vm_hostname, vm_version, travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: python
-python: 3.6
+python:
+- "3.6"
 
-install: 
- - pip install -r requirements.txt
+before_install:
+- pip install -U pip wheel setuptools
+
+install:
+- pip install -r requirements.txt
+- ansible-galaxy install -r requirements.yml
 
 script:
- - ansible-galaxy install -r requirements.yml
+- ansible-playbook playbook.yml --syntax-check

--- a/globalconfig.yml
+++ b/globalconfig.yml
@@ -1,7 +1,7 @@
 ---
 # Caution: This file is read by vagrant, ansible and bash
 vm_name: "Quantum Mobile"
-vm_version: "20.05.0"
+vm_version: "20.06.0"
 vm_description: "A Virtual Machine for Computational Materials Science"
 vm_url: "https://github.com/marvel-nccr/marvel-virtualmachine"
 vm_author: "MARVEL NCCR and MaX CoE"
@@ -10,7 +10,7 @@ vm_release_notes_file: "${HOME}/Desktop/release_notes.txt"
 vm_readme_file: "${HOME}/Desktop/README.md"
 
 # VM configuration
-vm_hostname: "workhorse"
+vm_hostname: "quantum-mobile"
 vm_user: "max"
 vm_memory: 4000
 vm_cpus: 2

--- a/requirements.yml
+++ b/requirements.yml
@@ -34,4 +34,4 @@
 - src: marvel-nccr.aiida
   version: v2.1.8
 - src: marvel-nccr.aiidalab
-  version: v1.1.3
+  version: v1.1.4


### PR DESCRIPTION
- Use aiidalab ansible role v1.1.4 (aiidalab pip package 20.06.0b1).
- Change `vm_hostname` to `quantum-mobile`.
- Change `vm_version` to `20.06.0`.
- Slightly improve Travis checks (copied over from QM Desktop Edition).