### PR TITLE
update-slurm-role

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Install pre-commit hooks via
+# pre-commit install
+
+exclude: >
+    (?x)^(
+      \.vscode/settings\.json
+    )$
+
+repos:
+
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    - id: check-json
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: trailing-whitespace
+
+  - repo: https://github.com/IamTheFij/docker-pre-commit
+    rev: v2.0.0
+    hooks:
+    - id: docker-compose-check

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2017, ECOLE POLYTECHNIQUE FEDERALE DE LAUSANNE
-(Theory and Simulation of Materials (THEOS) and National Centre for 
+(Theory and Simulation of Materials (THEOS) and National Centre for
 Computational Design and Discovery of Novel Materials (NCCR MARVEL)),
 Switzerland.
 
@@ -22,4 +22,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This procedure is automated entirely using the [ansible playbook](https://docs.a
 #### Server
 - A server running Ubuntu 18.04 LTS
   Can be hardware or virtual machine (tested on OpenStack, Amazon Web Services and Huawei Cloud).
-- At least 12GB disk size (including Ubuntu); better 15GB or more.  
+- At least 12GB disk size (including Ubuntu); better 15GB or more.
   Note: After cleaning temporary files, QM 20.3.1 occupied 6.1GB of disk space.
 - Access to server via SSH key as user with sudo rights
 
@@ -83,8 +83,8 @@ ansible-galaxy install -r requirements.yml  # installs ansible roles
    * `vm_user`: the user for which to install the simulation environment (usually *not* the admin user you are connecting as)
    * `vm_memory`, `vm_cpus`
 1. (optional) adaptation of the ansible `playbook.yml`
-   * 
-   * You want to preload a SSH public key for the `vm_user`?  
+   *
+   * You want to preload a SSH public key for the `vm_user`?
    Then uncomment the `"add user {{ vm_user }} with key"` role and adjust the path to the public key in the lookup for the `add_user_public_key` variable
    * Add/remove further roles depending on what you want to have in the image
 1. run `ansible-playbook playbook.yml`
@@ -97,7 +97,7 @@ You can log in to the server as the `vm_user` via the public SSH key you provide
 
 Before creating an image from the disk volume of the server you provisioned:
 
-1. Remove unnecessary temporary files:  
+1. Remove unnecessary temporary files:
    `ansible-playbook playbook.yml --extra-vars "clean=true" --tags qm_customizations,simulationbase`
 
 1. Clear bash history: `cat /dev/null > ~/.bash_history && history -c && exit`

--- a/globalconfig.yml
+++ b/globalconfig.yml
@@ -13,7 +13,6 @@ vm_readme_file: "${HOME}/Desktop/README.md"
 vm_hostname: "quantum-mobile"
 vm_user: "max"
 vm_memory: 4000
-vm_cpus: 2
 vm_codes_folder: "${HOME}/codes"
 vm_data_folder: "/usr/local/share"
 vm_examples_folder: "${HOME}/examples"

--- a/globalconfig.yml
+++ b/globalconfig.yml
@@ -12,6 +12,7 @@ vm_readme_file: "${HOME}/Desktop/README.md"
 # VM configuration
 vm_hostname: "quantum-mobile"
 vm_user: "max"
+vm_cpus: 2
 vm_memory: 4000
 vm_codes_folder: "${HOME}/codes"
 vm_data_folder: "/usr/local/share"

--- a/playbook.yml
+++ b/playbook.yml
@@ -97,7 +97,7 @@
         aiidalab_headless: "{{ vm_headless }}"
     # note: installing aiida role after aiidalab role, since aiida role has latest AiiDA version
     - role: marvel-nccr.aiida
-      tags: aiida 
+      tags: aiida
       become: true
       become_user: "{{ vm_user }}"
       vars:

--- a/playbook.yml
+++ b/playbook.yml
@@ -65,7 +65,6 @@
       tags: slurm
       vars:
         slurm_hostname: "{{ vm_hostname }}"
-        slurm_cpus: "{{ vm_cpus }}"
         slurm_memory: "{{ vm_memory }}"
         slurm_hostname_service: true
     - role: marvel-nccr.quantum_espresso
@@ -112,3 +111,8 @@
           - plugins
           - pseudopotentials
           - examples
+
+  post_tasks:
+    - name: run pip check (to detect version clashes)
+      command: "/home/max/.virtualenvs/aiida/bin/pip check --no-color"
+      changed_when: False

--- a/requirements.yml
+++ b/requirements.yml
@@ -26,12 +26,12 @@
 - src: marvel-nccr.cp2k
   version: v1.1.1
 - src: marvel-nccr.bigdft
-  version: v1.2.0
+  version: v1.3.0
 - src: marvel-nccr.wannier90
   version: v1.1.2
 - src: marvel-nccr.wannier_tools
   version: v1.0.0
 - src: marvel-nccr.aiida
-  version: v2.3.1
+  version: v2.3.2
 - src: marvel-nccr.aiidalab
-  version: v1.1.5
+  version: v1.2.2

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,7 +14,7 @@
 - src: marvel-nccr.editors
   version: v1.0.2
 - src: marvel-nccr.slurm
-  version: v1.1.0
+  version: v1.2.0
 - src: marvel-nccr.quantum_espresso
   version: v1.1.4
 - src: marvel-nccr.yambo

--- a/roles/xiamen_tutorial2019/files/pip.conf
+++ b/roles/xiamen_tutorial2019/files/pip.conf
@@ -1,3 +1,2 @@
 [global]
 index-url = https://mirrors.aliyun.com/pypi/simple
-

--- a/roles/xiamen_tutorial2019/tasks/main.yml
+++ b/roles/xiamen_tutorial2019/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: add user compute with key
-  include_role: 
+  include_role:
     name: marvel-nccr.add_user
   vars:
     add_user_name: "compute"


### PR DESCRIPTION
 closes #7

This PR updates marvel-nccr.slurm to the new version, in which a sizeable change was made to automate the selection of computer resources (see https://github.com/marvel-nccr/ansible-role-slurm/commit/db875b87a4ea70f058bdbcf6988617a5a85057e6). As such `vm_cpus` should no longer be needed.

Leaving this as a draft for now, as I'm going to build an AWS VM with this version now, and check it works as expected